### PR TITLE
Fix 404 link to instructions for registering an program in Azure AD.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You perform the following steps in this tutorial:
 * **Azure SQL Database**. You use the database as **sink** data store. If you don't have an Azure SQL Database, see the [Create an Azure SQL database](../sql-database/sql-database-get-started-portal.md) article for steps to create one.
 * **Visual Studio** 2013, 2015, or 2017. The walkthrough in this article uses Visual Studio 2017.
 * **Download and install [Azure .NET SDK](http://azure.microsoft.com/downloads/)**.
-* **Create an application in Azure Active Directory** following [this instruction](../azure-resource-manager/resource-group-create-service-principal-portal.md#create-an-azure-active-directory-application). Make note of the following values that you use in later steps: **application ID**, **authentication key**, and **tenant ID**. Assign application to "**Contributor**" role by following instructions in the same article.
+* **Create an application in Azure Active Directory** following [this instruction](https://github.com/Azure-Samples/data-factory-copy-blob-to-sql.git). Make note of the following values that you use in later steps: **application ID**, **authentication key**, and **tenant ID**. Assign application to "**Contributor**" role by following instructions in the same article.
 
 ### Create blob and SQL table
 


### PR DESCRIPTION
## Purpose
Replace a 404 link with useful content pointing to MSFT documentation on how to register a program with Azure AD.
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone https://github.com/rfreytag/data-factory-copy-blob-to-sql
cd data-factory-copy-blob-to-sql
git checkout master
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
Just read the README.md and click on the changed link to confirm a relevant Azure AD program registration page is opened.

## What to Check
New link works and is relevant to the text.
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->